### PR TITLE
Confusion_matrix(): plot only on given axes

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -49,8 +49,7 @@ def confusion_matrix(
             >>> confusion_matrix(truth, prediction, labels=['A', 'B', 'C', 'D'])
 
     """  # noqa: 501
-    sns.set()  # get prettier plots
-
+    ax = ax or plt.gca()
     labels = audmetric.core.utils.infer_labels(truth, prediction, labels)
 
     cm = audmetric.confusion_matrix(
@@ -73,10 +72,9 @@ def confusion_matrix(
         cmap="Blues",
         ax=ax,
     )
-    plt.yticks(rotation=0)
-    plt.xlabel('prediction')
-    plt.ylabel('truth')
-    plt.tight_layout()
+    ax.tick_params(axis='y', rotation=0)
+    ax.set_xlabel('prediction')
+    ax.set_ylabel('truth')
 
 
 def distribution(

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,10 @@ you can change the labels after plotting.
 
     import audplot
     import matplotlib.pyplot as plt
+    import seaborn as sns
 
+
+    sns.set()  # get prettier plots
 
     truth = ['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C']
     prediction = ['A', 'A', 'B', 'B', 'C', 'C', 'A', 'A', 'C']


### PR DESCRIPTION
We had a mix of plotting on a specified `ax` and the currently active axes (when calling `plt.*()` functions).

Also removes `plt.tight_layout()` and `sns.set()` as these should be explicitly called by the user.