### PR TITLE
Fix URLs to doc and source code of package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,9 @@
 name = audplot
 author = Johannes Wagner, Hagen Wierstorf
 author-email = jwagner@audeering.com, hwierstorf@audeering.com
-url = https://gitlab.audeering.com/tools/audplot/
+url = https://github.com/audeering/audplot/
 project-urls =
-    Documentation = http://tools.pp.audeering.com/audplot/
+    Documentation = https://audeering.github.io/audplot/
 description = A Python plotting package
 long-description = file: README.rst, CHANGELOG.rst
 license = MIT License


### PR DESCRIPTION
Before they were just pointing to the our internal locations.