### PR TITLE
CI: install missing libsndfile1 when publish docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,11 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Setup Ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install libsndfile1
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Closes #8.

Adds the missing `libsndfile1` package to the publish workflow.