### PR TITLE
Fix axis min and max for scatter() + series()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -208,6 +208,8 @@ def scatter(
 
     """
     ax = ax or plt.gca()
+    truth = list(truth)
+    prediction = list(prediction)
     minimum = min(truth + prediction)
     maximum = max(truth + prediction)
     ax.scatter(truth, prediction)
@@ -251,6 +253,8 @@ def series(
 
     """
     ax = ax or plt.gca()
+    truth = list(truth)
+    prediction = list(prediction)
     minimum = min(truth + prediction)
     maximum = max(truth + prediction)
     ax.plot(truth)

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -208,10 +208,8 @@ def scatter(
 
     """
     ax = ax or plt.gca()
-    truth = list(truth)
-    prediction = list(prediction)
-    minimum = min(truth + prediction)
-    maximum = max(truth + prediction)
+    minimum = min([min(truth), min(prediction)])
+    maximum = max([max(truth), max(prediction)])
     ax.scatter(truth, prediction)
     ax.plot(
         [minimum, maximum],
@@ -253,10 +251,8 @@ def series(
 
     """
     ax = ax or plt.gca()
-    truth = list(truth)
-    prediction = list(prediction)
-    minimum = min(truth + prediction)
-    maximum = max(truth + prediction)
+    minimum = min([min(truth), min(prediction)])
+    maximum = max([max(truth), max(prediction)])
     ax.plot(truth)
     ax.plot(prediction)
     ax.set_ylim(minimum, maximum)


### PR DESCRIPTION
Closes #11 

This fixes the calculation of min and max values to scale the axis for `audplot.scatter()` and `audplot.series()`.

I solved it by `min([min(truth), min(prediction)])`, ...