### PR TITLE
Update percentage-wise confusion matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,11 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Setup Ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install libsndfile1
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -123,15 +123,45 @@ def confusion_matrix(
         truth,
         prediction,
         labels=labels,
-        normalize=percentage,
+        normalize=False,
     )
     if percentage:
-        fmt = '.0%'
+        cm_perc = audmetric.confusion_matrix(
+            truth,
+            prediction,
+            labels=labels,
+            normalize=True,
+        )
+        results = pd.concat(
+            (
+                pd.DataFrame(
+                    data=cm,
+                    index=labels,
+                    columns=labels
+                ),
+                pd.DataFrame(
+                    data=cm_perc,
+                    index=labels,
+                    columns=[f'{x}.perc' for x in labels]
+                )
+            ), axis=1
+        )
+        for key in labels:
+            perc = f'{key}.perc'
+            results[f'{key}.print'] = results.apply(
+                lambda x: f"{int(x[key]):d}\n({x[perc]:.0%})", axis=1
+            )
+        data = results[[f'{key}' for key in labels]].values
+        annot = results[[f'{key}.print' for key in labels]].values
+        fmt = ''
     else:
         fmt = 'd'
+        data = cm
+        annot = True
+        
     sns.heatmap(
-        cm,
-        annot=True,
+        data,
+        annot=annot,
         xticklabels=labels,
         yticklabels=labels,
         cbar=False,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -117,6 +117,20 @@ def confusion_matrix(
         .. plot::
             :context: close-figs
 
+            >>> truth = ['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C']
+            >>> prediction = ['A', 'A', 'B', 'B', 'C', 'C', 'A', 'A', 'C']
+            >>> confusion_matrix(truth, prediction, percentage=True)
+
+        .. plot::
+            :context: close-figs
+
+            >>> truth = ['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C']
+            >>> prediction = ['A', 'A', 'B', 'B', 'C', 'C', 'A', 'A', 'C']
+            >>> confusion_matrix(truth, prediction, percentage=True, support=True) 
+
+        .. plot::
+            :context: close-figs
+
             >>> confusion_matrix(truth, prediction, labels=['A', 'B', 'C', 'D'])
 
     """  # noqa: 501
@@ -167,7 +181,7 @@ def confusion_matrix(
         fmt = 'd'
         data = cm
         annot = True
-        
+
     sns.heatmap(
         data,
         annot=annot,


### PR DESCRIPTION
Changes: Generated table now shows number of samples and percentages in parentheses.

@hagenw as discussed internally, this PR changes what confusion matrix with `percentage=True` returns. Background: I argued that the support information is critical for confusion matrices and was missing for percentage-wise ones.

Adding a preview of the generated confusion matrix for easier reference, though you can build the docs locally and check it out:
![orig](https://user-images.githubusercontent.com/14807371/126627328-0251c4eb-46f2-4448-9be4-3430f96b30ab.png)

Before you begin with code review, there are two points to discuss:

1. Do you agree with the proposed formatting (cc'ing @frankenjoe here)
2. My proposed changes completely remove the option to plot just the percentages. However, I agree that on some cases it might be useful. I could not find a way to do it with a boolean flag though (`percentage=True/False`). I would need to add an extra value, e.g. (`percentage=True/False/'both'`) or something similar. What do you think?