### PR TITLE
Add audplot.human_format()

### DIFF
--- a/audplot/__init__.py
+++ b/audplot/__init__.py
@@ -2,6 +2,7 @@ from audplot.core.api import (
     cepstrum,
     confusion_matrix,
     distribution,
+    human_format,
     scatter,
     series,
     signal,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -199,6 +199,7 @@ def human_format(
 
     Raises:
         ValueError: if ``number`` :math:`\ge 1000^9`
+            or ``number`` :math:`\le 1000^{-4}`
 
     Example:
         >>> human_format(12345)
@@ -207,21 +208,35 @@ def human_format(
         '1.2M'
         >>> human_format(123456789000)
         '123B'
+        >>> human_format(0.000123)
+        '123u'
 
     """
-    units = ['', 'k', 'M', 'B', 'T', 'P', 'E', 'Z', 'Y']
+    units = [
+        'n',  # 10^-9  nano
+        'u',  # 10^-6  micro
+        'm',  # 10^-3  milli
+        '',   # 0
+        'k',  # 10^3   thousand
+        'M',  # 10^6   Million      Mega
+        'B',  # 10^9   Billion      Giga
+        'T',  # 10^12  Trillion     Tera
+        'P',  # 10^15  Quadrillion  Peta
+        'E',  # 10^18  Quintillion  Exa
+        'Z',  # 10^21  Sextillion   Zetta
+        'Y',  # 10^24  Septillion   Yotta
+    ]
     k = 1000.0
     magnitude = int(math.floor(math.log(number, k)))
     number = f'{number / k**magnitude:.1f}'
     # Make sure we show only up to 3 significant digits
     if len(number) > 4:
         number = number[:-2]
-    if magnitude >= len(units):
-        raise ValueError(
-            'Only magnitudes < 1000 ** {len(units) + 1} '
-            'are supported.'
-        )
-    return f'{number}{units[magnitude]}'
+    if magnitude >= 9:
+        raise ValueError('Only magnitudes < 1000 ** 9 are supported.')
+    if magnitude <= -4:
+        raise ValueError('Only magnitudes > 1000 ** -4 are supported.')
+    return f'{number}{units[magnitude + 3]}'
 
 
 def scatter(

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -1,3 +1,4 @@
+import math
 import typing
 
 import matplotlib
@@ -177,6 +178,50 @@ def distribution(
     sns.distplot(truth, axlabel='', ax=ax)
     sns.distplot(prediction, axlabel='', ax=ax)
     ax.legend(['Truth', 'Prediction'])
+
+
+def human_format(
+        number: typing.Union[int, float],
+) -> str:
+    r"""Display long numbers in a short human readable way.
+
+    It replaces ling numbers
+    by no more than 3 significant digits
+    and no more than 1 fractional digit,
+    and adds a string indicating the base,
+    e.g. 12345 becomes 12.3k.
+
+    Args:
+        number: input number
+
+    Returns:
+        formatted number string
+
+    Raises:
+        ValueError: if ``number`` :math:`\ge 1000^9`
+
+    Example:
+        >>> human_format(12345)
+        '12.3k'
+        >>> human_format(1234567)
+        '1.2M'
+        >>> human_format(123456789000)
+        '123B'
+
+    """
+    units = ['', 'k', 'M', 'B', 'T', 'P', 'E', 'Z', 'Y']
+    k = 1000.0
+    magnitude = int(math.floor(math.log(number, k)))
+    number = f'{number / k**magnitude:.1f}'
+    # Make sure we show only up to 3 significant digits
+    if len(number) > 4:
+        number = number[:-2]
+    if magnitude >= len(units):
+        raise ValueError(
+            'Only magnitudes < 1000 ** {len(units) + 1} '
+            'are supported.'
+        )
+    return f'{number}{units[magnitude]}'
 
 
 def scatter(

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -183,13 +183,32 @@ def distribution(
 def human_format(
         number: typing.Union[int, float],
 ) -> str:
-    r"""Display long numbers in a short human readable way.
+    r"""Display large or small numbers in a human readable way.
 
-    It replaces ling numbers
+    It replaces large or small numbers
     by no more than 3 significant digits
-    and no more than 1 fractional digit,
-    and adds a string indicating the base,
+    and no more than 1 fractional digit.
+    Instead it adds a string indicating the base,
     e.g. 12345 becomes 12.3k.
+
+    The naming is according to:
+
+    .. table::
+        :widths: 10 10 15 12
+
+        = =============== =========== =====
+        n :math:`10^{-9}` nano
+        u :math:`10^{-6}` micro
+        m :math:`10^{-3}` milli
+        k :math:`10^{3}`  thousand
+        M :math:`10^{6}`  Million     Mega
+        B :math:`10^{9}`  Billion     Giga
+        T :math:`10^{12}` Trillion    Tera
+        P :math:`10^{15}` Quadrillion Peta
+        E :math:`10^{18}` Quintillion Exa
+        Z :math:`10^{21}` Sextillion  Zetta
+        Y :math:`10^{24}` Septillion  Yotta
+        = =============== =========== =====
 
     Args:
         number: input number

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,11 @@ distribution
 
 .. autofunction:: distribution
 
+human_format
+------------
+
+.. autofunction:: human_format
+
 scatter
 -------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_autodoc_typehints',
     'sphinx_copybutton',  # for "copy to clipboard" buttons
+    'sphinxcontrib.katex',  # has to be before jupyter_sphinx
     'matplotlib.sphinxext.plot_directive',  # include resulting figures in doc
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx
 sphinx-audeering-theme >=1.0.8
 sphinx-autodoc-typehints
 sphinx-copybutton
+sphinxcontrib-katex

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,3 +6,5 @@ import audplot
 def test_human_format():
     with pytest.raises(ValueError):
         audplot.human_format(1000 ** 9)
+    with pytest.raises(ValueError):
+        audplot.human_format(1000 ** -4)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,8 @@
+import pytest
+
+import audplot
+
+
+def test_human_format():
+    with pytest.raises(ValueError):
+        audplot.human_format(1000 ** 9)


### PR DESCRIPTION
Adds `audplot.human_format()` to format large or small numbers.

![audplot-human-format](https://user-images.githubusercontent.com/173624/127116554-2738da32-98a4-4aa4-b34a-375b514abe8d.png)
