### PR TITLE
Fix human_format() for <=0 and remove .0

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -229,8 +229,18 @@ def human_format(
         '123B'
         >>> human_format(0.000123)
         '123u'
+        >>> human_format(0)
+        '0'
+        >>> human_format(-1000)
+        '-1k'
 
     """
+    sign = ''
+    if number == 0:
+        return '0'
+    if number < 0:
+        sign = '-'
+        number = -1 * number
     units = [
         'n',  # 10^-9  nano
         'u',  # 10^-6  micro
@@ -248,14 +258,16 @@ def human_format(
     k = 1000.0
     magnitude = int(math.floor(math.log(number, k)))
     number = f'{number / k**magnitude:.1f}'
-    # Make sure we show only up to 3 significant digits
-    if len(number) > 4:
-        number = number[:-2]
     if magnitude >= 9:
         raise ValueError('Only magnitudes < 1000 ** 9 are supported.')
     if magnitude <= -4:
         raise ValueError('Only magnitudes > 1000 ** -4 are supported.')
-    return f'{number}{units[magnitude + 3]}'
+    # Make sure we show only up to 3 significant digits
+    if len(number) > 4:
+        number = number[:-2]
+    if number.endswith('.0'):
+        number = number[:-2]
+    return f'{sign}{number}{units[magnitude + 3]}'
 
 
 def scatter(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,8 +3,37 @@ import pytest
 import audplot
 
 
-def test_human_format():
-    with pytest.raises(ValueError):
-        audplot.human_format(1000 ** 9)
-    with pytest.raises(ValueError):
-        audplot.human_format(1000 ** -4)
+@pytest.mark.parametrize(
+    'number, expected_string',
+    [
+        (0, '0'),
+        (1, '1'),
+        (10, '10'),
+        (100, '100'),
+        (1000, '1k'),
+        (10000, '10k'),
+        (100000, '100k'),
+        (1000000, '1M'),
+        (0.1, '100m'),
+        (0.01, '10m'),
+        (0.001, '1m'),
+        (0.0015, '1.5m'),
+        (0.0001, '100u'),
+        (-1, '-1'),
+        (-0.001, '-1m'),
+        (-0.0015, '-1.5m'),
+        pytest.param(
+            1000 ** 9,
+            '',
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            1000 ** -4,
+            '',
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_human_format(number, expected_string):
+    string = audplot.human_format(number)
+    assert string == expected_string


### PR DESCRIPTION
Before the code was failing for numbers <= 0 as `math.floor(math.log(number, k))` failed.
This is now covered.

Also `'1.0k'` etc. is shortened to `'1k'`.

The docstring examples are extended to:

![image](https://user-images.githubusercontent.com/173624/127127470-ab5bad04-80e7-4b2c-bb18-505124d90e92.png)
