### PR TITLE
Add second_annotation argument to confusion_matrix

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -83,6 +83,7 @@ def confusion_matrix(
         *,
         labels: typing.Sequence = None,
         percentage: bool = True,
+        second_row: bool = False,
         ax: plt.Axes = None,
 ):
     r"""Confusion matrix between ground truth vs. predicted labels.
@@ -95,6 +96,12 @@ def confusion_matrix(
         labels: labels to be included in confusion matrix
         percentage: if ``True`` present the confusion matrix
             with percentage values instead of absolute numbers
+        second_row: if ``True`` and percentage is ``True``
+            it shows number of support samples in brackets
+            in a second row.
+            If ``True`` and percentage is ``False``
+            it shows the percentage in brackets
+            in a second row
         ax: axes in which to draw the plot
 
     Example:
@@ -120,18 +127,18 @@ def confusion_matrix(
     ax = ax or plt.gca()
     labels = audmetric.core.utils.infer_labels(truth, prediction, labels)
 
-    cm = audmetric.confusion_matrix(
+    cm_first = audmetric.confusion_matrix(
         truth,
         prediction,
         labels=labels,
-        normalize=False,
+        normalize=percentage,
     )
-    if percentage:
-        cm_perc = audmetric.confusion_matrix(
+    if second_row:
+        cm_second = audmetric.confusion_matrix(
             truth,
             prediction,
             labels=labels,
-            normalize=True,
+            normalize=not percentage,
         )
         results = pd.concat(
             (

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -124,15 +124,45 @@ def confusion_matrix(
         truth,
         prediction,
         labels=labels,
-        normalize=percentage,
+        normalize=False,
     )
     if percentage:
-        fmt = '.0%'
+        cm_perc = audmetric.confusion_matrix(
+            truth,
+            prediction,
+            labels=labels,
+            normalize=True,
+        )
+        results = pd.concat(
+            (
+                pd.DataFrame(
+                    data=cm,
+                    index=labels,
+                    columns=labels
+                ),
+                pd.DataFrame(
+                    data=cm_perc,
+                    index=labels,
+                    columns=[f'{x}.perc' for x in labels]
+                )
+            ), axis=1
+        )
+        for key in labels:
+            perc = f'{key}.perc'
+            results[f'{key}.print'] = results.apply(
+                lambda x: f"{int(x[key]):d}\n({x[perc]:.0%})", axis=1
+            )
+        data = results[[f'{key}' for key in labels]].values
+        annot = results[[f'{key}.print' for key in labels]].values
+        fmt = ''
     else:
         fmt = 'd'
+        data = cm
+        annot = True
+        
     sns.heatmap(
-        cm,
-        annot=True,
+        data,
+        annot=annot,
         xticklabels=labels,
         yticklabels=labels,
         cbar=False,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -86,7 +86,7 @@ def confusion_matrix(
         show_both: bool = False,
         ax: plt.Axes = None,
 ):
-    r"""Confusion matrix between ground truth vs. predicted labels.
+    r"""Confusion matrix between ground truth and prediction.
 
     The confusion matrix is calculated by :mod:`audmetric.confusion_matrix`.
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -83,7 +83,7 @@ def confusion_matrix(
         *,
         labels: typing.Sequence = None,
         percentage: bool = True,
-        second_annotation: bool = False,
+        show_both: bool = False,
         ax: plt.Axes = None,
 ):
     r"""Confusion matrix between ground truth vs. predicted labels.
@@ -96,7 +96,7 @@ def confusion_matrix(
         labels: labels to be included in confusion matrix
         percentage: if ``True`` present the confusion matrix
             with percentage values instead of absolute numbers
-        second_annotation: if ``True`` and percentage is ``True``
+        show_both: if ``True`` and percentage is ``True``
             it shows absolute numbers in brackets 
             below percentage values.
             If ``True`` and percentage is ``False``
@@ -126,12 +126,12 @@ def confusion_matrix(
         .. plot::
             :context: close-figs
 
-            >>> confusion_matrix(truth, prediction, second_annotation=True)
+            >>> confusion_matrix(truth, prediction, show_both=True)
 
         .. plot::
             :context: close-figs
 
-            >>> confusion_matrix(truth, prediction, percentage=False, second_annotation=True)
+            >>> confusion_matrix(truth, prediction, percentage=False, show_both=True)
 
         .. plot::
             :context: close-figs
@@ -157,7 +157,7 @@ def confusion_matrix(
         annot = cm.applymap(lambda x: human_format(x))
 
     # Add a second row of annotations if requested
-    if second_annotation:
+    if show_both:
         cm2 = audmetric.confusion_matrix(
             truth,
             prediction,


### PR DESCRIPTION
**NOTE:** ~~this does not merge into `master`, but into `percentagewise-confusion`~~, changed to `master` as `percentagewise-confusion` changed in the mean time

This adds the `second_annotation` argument to `audplot.confusion_matrix()` and allows to create all four variations of the confusion matrix as discussed in https://github.com/audeering/audplot/pull/13#issuecomment-886460487

It also solves the problem of long string for high number of samples by using `audplot.human_format()` which returns strings in the form of `1.2k`.

I have not changed the default behavior (`percentage=True`) of `confusion_matrix()` as this should be done in a separate pull request if needed.

The docstring contains now examples for all possible combinations and one for the optional `labels` argument:

![confusion-matrix-second-annotation](https://user-images.githubusercontent.com/173624/127147194-cf829701-9cc9-401e-a114-f0488b8a498d.png)
