### PR TITLE
percentage=False new default in confusion_matrix

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -82,7 +82,7 @@ def confusion_matrix(
         prediction: typing.Union[typing.Sequence, pd.Series],
         *,
         labels: typing.Sequence = None,
-        percentage: bool = True,
+        percentage: bool = False,
         show_both: bool = False,
         ax: plt.Axes = None,
 ):
@@ -121,7 +121,7 @@ def confusion_matrix(
         .. plot::
             :context: close-figs
 
-            >>> confusion_matrix(truth, prediction, percentage=False)
+            >>> confusion_matrix(truth, prediction, percentage=True)
 
         .. plot::
             :context: close-figs
@@ -131,7 +131,7 @@ def confusion_matrix(
         .. plot::
             :context: close-figs
 
-            >>> confusion_matrix(truth, prediction, percentage=False, show_both=True)
+            >>> confusion_matrix(truth, prediction, percentage=True, show_both=True)
 
         .. plot::
             :context: close-figs


### PR DESCRIPTION
Changes the default behavior of `audplot.confusion_matrix` from `percentage=True` to `percentage=False`.

![confusion-matrix-default](https://user-images.githubusercontent.com/173624/127148612-f5c7a8e0-cd1e-444e-bb0f-3ecfac1667fa.png)
