### PR TITLE
Add audplot.detection_error_tradeoff()

### DIFF
--- a/audplot/__init__.py
+++ b/audplot/__init__.py
@@ -1,6 +1,7 @@
 from audplot.core.api import (
     cepstrum,
     confusion_matrix,
+    detection_error_tradeoff,
     distribution,
     human_format,
     scatter,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -296,14 +296,14 @@ def detection_error_tradeoff(
 
     """  # noqa: E501
     if not error_rates:
-        fmr, fnmr, _ = audmetric.detection_error_tradeoff(x, y)
+        x, y, _ = audmetric.detection_error_tradeoff(x, y)
 
     # Transform values to the normal derivate scale
     transform = inverse_normal_distribution
 
     g = sns.lineplot(
-        x=transform(fmr),
-        y=transform(fnmr),
+        x=transform(x),
+        y=transform(y),
         label=label,
     )
     # plt.axis('equal')

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -280,7 +280,6 @@ def detection_error_tradeoff(
             >>> pred2[:1000] = np.random.normal(loc=0.6, scale=0.1, size=1000)
             >>> pred2[1000:] = np.random.normal(loc=0.4, scale=0.1, size=1000)
             >>> pred2 = np.clip(pred2, 0, 1)
-            >>> ax_lim = [0.01, 0.99]
             >>> transform = detection_error_tradeoff(
             ...     truth,
             ...     pred1,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -306,7 +306,6 @@ def detection_error_tradeoff(
         y=transform(y),
         label=label,
     )
-    # plt.axis('equal')
     plt.title('Detection Error Tradeoff (DET) Curve')
     plt.xlabel('False Match Rate')
     plt.ylabel('False Non-Match Rate')

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -195,6 +195,39 @@ def confusion_matrix(
     ax.set_ylabel('Truth')
 
 
+def detection_error_tradeoff(
+        truth: typing.Union[typing.Sequence, pd.Series],
+        prediction: typing.Union[typing.Sequence, pd.Series],
+        *,
+        ax: plt.Axes = None,
+):
+    r"""Detection error tradeoff curve.
+
+    A `detection error tradeoff (DET)`_ curve
+    is a graphical plot of error rates for binary classification systems,
+    plotting the false non-matching rate (FNMR)
+    vs. false match rate (FMR).
+
+    The axis are scaled non-linearly
+    by their `standard normal deviates`_.
+
+    .. _detection error tradeoff (DET): https://en.wikipedia.org/wiki/Detection_error_tradeoff
+    .. _standard normal deviates: https://en.wikipedia.org/wiki/Standard_normal_deviate
+
+    Args:
+        truth: truth values
+        prediction: predicted values
+        ax: axes in which to draw the plot
+
+    """  # noqa: E501
+    fmr, fnmr, _ = audmetric.detection_error_tradeoff(truth, prediction)
+
+    # TODO: implement this code here!
+    # Transform values to the normal derivate scale
+    transform = scipy.stats.norm.ppf
+
+
+
 def distribution(
         truth: typing.Union[typing.Sequence, pd.Series],
         prediction: typing.Union[typing.Sequence, pd.Series],

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
+import audmath
 import audmetric
 
 
@@ -220,13 +221,50 @@ def detection_error_tradeoff(
         prediction: predicted values
         ax: axes in which to draw the plot
 
+    Example:
+        .. plot::
+            :context: reset
+            :include-source: false
+
+            import numpy as np
+            from audplot import detection_error_tradeoff
+
+            np.random.seed(0)
+
+        .. plot::
+            :context: close-figs
+
+            >>> truth = np.array([1] * 1000 + [0] * 1000)
+            >>> prediction = np.random.rand(2000)
+            >>> detection_error_tradeoff(truth, prediction)
+
     """  # noqa: E501
     fmr, fnmr, _ = audmetric.detection_error_tradeoff(truth, prediction)
 
-    # TODO: implement this code here!
     # Transform values to the normal derivate scale
-    transform = scipy.stats.norm.ppf
+    transform = audmath.inverse_normal_distribution
 
+    g = sns.lineplot(
+        x=transform(fmr),
+        y=transform(fnmr),
+    )
+    plt.title('Detection Error Tradeoff (DET) Curve')
+    plt.xlabel('False Alarm Probability')
+    plt.ylabel('Miss Probability')
+    plt.grid(alpha=0.4)
+
+    ticks = [0.001, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.4]
+    tick_locations = transform(ticks)
+    tick_labels = [
+        f'{t:.0%}' if (100 * t).is_integer() else f'{t:.1%}'
+        for t in ticks
+    ]
+    g.set(xticks=tick_locations, xticklabels=tick_labels)
+    g.set(yticks=tick_locations, yticklabels=tick_labels)
+    plt.xlim(transform(0.0001), transform(0.99))
+    plt.ylim(transform(0.001), transform(0.99))
+
+    sns.despine()
 
 
 def distribution(

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -276,7 +276,7 @@ def detection_error_tradeoff(
             >>> import audmetric
             >>> fmr, fnmr, _ = audmetric.detection_error_tradeoff(truth, pred2)
             >>> _ = plt.plot(transform(fmr), transform(fnmr), label='pred2')
-            >>> plt.legend()
+            >>> _ = plt.legend()
             >>> plt.tight_layout()
 
     """  # noqa: E501

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -140,7 +140,8 @@ def confusion_matrix(
 
     """  # noqa: 501
     ax = ax or plt.gca()
-    labels = audmetric.core.utils.infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = audmetric.utils.infer_labels(truth, prediction)
 
     cm = audmetric.confusion_matrix(
         truth,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,11 @@ confusion_matrix
 
 .. autofunction:: confusion_matrix
 
+detection_error_tradeoff
+------------------------
+
+.. autofunction:: detection_error_tradeoff
+
 distribution
 ------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audmetric >=1.0.1, <2.0.0
+    audmath
+    audmetric >=1.1.0
     seaborn
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
This adds the [Detection error tradeoff (DET) curve](https://en.wikipedia.org/wiki/Detection_error_tradeoff) as `audplot.detection_error_tradeoff()`.

A user can provide `truth` and `prediction` values as with our other machine learning focused plotting functions, or she can directly provide the false match rate (FMR) and false non-match rate (FNMR) which she might have calculated already, e.g. when using `audmetric.equal_error_rate()`.

![image](https://user-images.githubusercontent.com/173624/127637527-09dfb79b-aa2c-4f67-ae53-d955c7965759.png)
