### PR TITLE
Add audplot.waveform()

### DIFF
--- a/audplot/__init__.py
+++ b/audplot/__init__.py
@@ -8,6 +8,7 @@ from audplot.core.api import (
     series,
     signal,
     spectrum,
+    waveform,
 )
 
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -654,7 +654,6 @@ def waveform(
         color: typing.Union[str, typing.Sequence[float]] = '#E13B41',
         background: typing.Union[str, typing.Sequence[float]] = (0, 0, 0, 0),
         linewidth: float = 1.5,
-        figsize: typing.Sequence[float] = (8, 1),
         ylim: typing.Sequence[float] = (-1, 1),
         ax: plt.Axes = None,
 ):

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -673,7 +673,7 @@ def waveform(
         linewidth: line width of signal
         figsize: size of figure.
             Takes only effect
-            if ``fig`` and/or ``ax`` are ``None``
+            if no current figure exists already
         ylim: limits of y-axis
         fig: Pre-existing figure for the plot.
             Otherwise, call :func:`matplotlib.pyplot.gcf()` internally

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -645,3 +645,73 @@ def spectrum(
     )
 
     return image
+
+
+def waveform(
+        x: np.ndarray,
+        *,
+        text: str = None,
+        color: typing.Union[str, typing.Sequence] = '#E13B41',
+        background: typing.Union[str, typing.Sequence] = (0, 0, 0, 0),
+        ax: plt.Axes = None,
+):
+    r"""Waveform.
+
+    Shows only the outline of a time signal
+    without showing any axis or values.
+
+    Args:
+        x: array with signal values
+        text: optional text to be displayed
+            on the left side of the waveform
+        color: color of wave form and text
+        background: color of background
+        ax: axes to plot on
+
+    Example:
+        .. plot::
+            :context: reset
+            :include-source: false
+
+            from audplot import waveform
+
+        .. plot::
+            :context: close-figs
+
+            >>> import librosa
+            >>> x, sr = librosa.load(librosa.ex('trumpet'))
+            >>> wavform(x, text='Trumpet')
+
+    """
+    x = np.atleast_2d(x)
+    channels, samples = x.shape
+    # TODO: include ax object
+    ax = ax or plt.gca()
+    # TODO: check how to use sns.set() only for one plot
+    sns.set(
+        rc={
+            'axes.facecolor': background,
+            'figure.facecolor': background,
+            'axes.grid': False,
+            'figure.figsize': (8, 3 * channels),
+        },
+    )
+    for mono in x:
+        g = sns.lineplot(data=mono, color=color, linewidth=2.5)
+        # Remove all axis
+        sns.despine(left=True, bottom=True)
+        g.tick_params(left=False, bottom=False)
+        _ = g.set(xticklabels=[], yticklabels=[])
+        # TODO: adjust position not based on samples, but on figure size
+        _ = plt.xlim([-0.15 * samples, samples])
+        _ = plt.ylim([-1, 1])
+        _ = plt.text(
+            -0.02 * samples,
+            0,
+            text,
+            fontsize='large',
+            fontweight='semibold',
+            color=color,
+            horizontalalignment='right',
+            verticalalignment='center',
+        )

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -656,6 +656,7 @@ def waveform(
         linewidth: float = 1.5,
         figsize: typing.Sequence[float] = (8, 1),
         ylim: typing.Sequence[float] = (-1, 1),
+        fig: plt.figure = None,
         ax: plt.Axes = None,
 ):
     r"""Plot waveform of a mono signal.
@@ -670,8 +671,12 @@ def waveform(
         color: color of wave form and text
         background: color of background
         linewidth: line width of signal
-        figsize: size of figure
+        figsize: size of figure.
+            Takes only effect
+            if ``fig`` and/or ``ax`` are ``None``
         ylim: limits of y-axis
+        fig: Pre-existing figure for the plot.
+            Otherwise, call :func:`matplotlib.pyplot.gcf()` internally
         ax: axes to plot on
 
     Raises:
@@ -704,7 +709,7 @@ def waveform(
             >>> import librosa
             >>> import matplotlib.pyplot as plt
             >>> x, _ = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
-            >>> _, axs = plt.subplots(2, figsize=(8, 3))
+            >>> fig, axs = plt.subplots(2, figsize=(8, 3))
             >>> plt.subplots_adjust(hspace=0)
             >>> waveform(
             ...     x[0, :],
@@ -712,6 +717,7 @@ def waveform(
             ...     linewidth=0.5,
             ...     background='#389DCD',
             ...     color='#1B5975',
+            ...     fig=fig,
             ...     ax=axs[0],
             ... )
             >>> waveform(
@@ -720,19 +726,25 @@ def waveform(
             ...     linewidth=0.5,
             ...     background='#CA5144',
             ...     color='#742A23',
+            ...     fig=fig,
             ...     ax=axs[1],
             ... )
 
     """
+    # Setting the figsize has to be done first
+    # before requesting axis or figure.
+    # If axis/figure exist already it will have no effect
+    if figsize is not None:
+        plt.rcParams['figure.figsize'] = figsize
+
+    fig = fig or plt.gcf()
+    ax = ax or plt.gca()
+
     x = np.atleast_2d(x)
     channels, samples = x.shape
     if channels > 1:
         raise RuntimeError('Only mono signals are supported.')
-    if figsize is not None:
-        plt.rcParams['figure.figsize'] = figsize
-
     # Set colors
-    ax = ax or plt.gca()
     ax.grid(False)
     ax.set_facecolor(background)
     # Plot waveform
@@ -763,7 +775,6 @@ def waveform(
             verticalalignment='center',
         )
         # Get left position of text and adjust xlim accordingly
-        fig = plt.gcf()
         bb = text.get_window_extent(renderer=fig.canvas.get_renderer())
         transform = ax.transData.inverted()
         bb = bb.transformed(transform)

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -652,7 +652,7 @@ def waveform(
         *,
         text: str = None,
         color: typing.Union[str, typing.Sequence[float]] = '#E13B41',
-        background: typing.Union[str, typing.Sequence[float]] = (0, 0, 0, 0),
+        background: typing.Union[str, typing.Sequence[float]] = '#FFFFFF00',
         linewidth: float = 1.5,
         ylim: typing.Sequence[float] = (-1, 1),
         ax: plt.Axes = None,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -671,9 +671,6 @@ def waveform(
         color: color of wave form and text
         background: color of background
         linewidth: line width of signal
-        figsize: size of figure.
-            Takes only effect
-            if no current figure exists already
         ylim: limits of y-axis
         fig: Pre-existing figure for the plot.
             Otherwise, call :func:`matplotlib.pyplot.gcf()` internally
@@ -734,8 +731,10 @@ def waveform(
     # Setting the figsize has to be done first
     # before requesting axis or figure.
     # If axis/figure exist already it will have no effect
-    if figsize is not None:
-        plt.rcParams['figure.figsize'] = figsize
+
+    # Set default figsize if no existing figure is used
+    default_figsize = plt.rcParams['figure.figsize']
+    plt.rcParams['figure.figsize'] = (8, 1)
 
     fig = fig or plt.gcf()
     ax = ax or plt.gca()
@@ -782,3 +781,6 @@ def waveform(
     else:
         xlim = (0, samples)
     ax.set(xlim=xlim)
+
+    # Restore default figure size
+    plt.rcParams['figure.figsize'] = default_figsize

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -105,7 +105,7 @@ def confusion_matrix(
         percentage: if ``True`` present the confusion matrix
             with percentage values instead of absolute numbers
         show_both: if ``True`` and percentage is ``True``
-            it shows absolute numbers in brackets 
+            it shows absolute numbers in brackets
             below percentage values.
             If ``True`` and percentage is ``False``
             it shows the percentage in brackets
@@ -651,14 +651,14 @@ def waveform(
         x: np.ndarray,
         *,
         text: str = None,
-        color: typing.Union[str, typing.Sequence] = '#E13B41',
-        background: typing.Union[str, typing.Sequence] = (0, 0, 0, 0),
-        linewidth: float = 2,
+        color: typing.Union[str, typing.Sequence[float]] = '#E13B41',
+        background: typing.Union[str, typing.Sequence[float]] = (0, 0, 0, 0),
+        linewidth: float = 1.5,
         figsize: typing.Sequence[float] = (8, 1),
         ylim: typing.Sequence[float] = (-1, 1),
         ax: plt.Axes = None,
 ):
-    r"""Waveform.
+    r"""Plot waveform of a mono signal.
 
     Shows only the outline of a time signal
     without showing any axis or values.
@@ -696,27 +696,32 @@ def waveform(
             :context: close-figs
 
             >>> import librosa
+            >>> x, _ = librosa.load(librosa.ex('trumpet'))
+            >>> waveform(x, background='#363636', color='#f6f6f6')
+
+        .. plot::
+            :context: close-figs
+
+            >>> import librosa
             >>> import matplotlib.pyplot as plt
             >>> x, _ = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
-            >>> _, axs = plt.subplots(2, figsize=(8, 2))
+            >>> _, axs = plt.subplots(2, figsize=(8, 3))
             >>> plt.subplots_adjust(hspace=0)
             >>> waveform(
             ...     x[0, :],
-            ...     text='Trumpet L',
+            ...     text='Left ',  # empty space for same size as 'Right'
             ...     linewidth=0.5,
             ...     background='#389DCD',
             ...     color='#1B5975',
             ...     ax=axs[0],
-            ...     figsize=None,
             ... )
             >>> waveform(
             ...     x[1, :],
-            ...     text='Trumpet R',
+            ...     text='Right',
             ...     linewidth=0.5,
             ...     background='#CA5144',
             ...     color='#742A23',
             ...     ax=axs[1],
-            ...     figsize=None,
             ... )
 
     """
@@ -738,26 +743,32 @@ def waveform(
         linewidth=linewidth,
         ax=ax,
     )
-    plt.ylim(ylim)
+    ax.set(ylim=ylim)
+
     # Remove all axis
     sns.despine(left=True, bottom=True)
     ax.tick_params(left=False, bottom=False)
     ax.set(xticklabels=[], yticklabels=[])
-    space_around_text = 0.02 * samples
+
     # Add text before waveform
-    text = plt.text(
-        -space_around_text,
-        0,
-        text,
-        fontsize='large',
-        fontweight='semibold',
-        color=color,
-        horizontalalignment='right',
-        verticalalignment='center',
-    )
-    # Get left position of text and adjust xlim accordingly
-    fig = plt.gcf()
-    bb = text.get_window_extent(renderer=fig.canvas.get_renderer())
-    transform = ax.transData.inverted()
-    bb = bb.transformed(transform)
-    plt.xlim([bb.x0 - space_around_text, samples])
+    if text is not None and len(text) > 0:
+        space_around_text = 0.02 * samples
+        text = ax.text(
+            -space_around_text,
+            0,
+            text,
+            fontsize='large',
+            fontweight='semibold',
+            color=color,
+            horizontalalignment='right',
+            verticalalignment='center',
+        )
+        # Get left position of text and adjust xlim accordingly
+        fig = plt.gcf()
+        bb = text.get_window_extent(renderer=fig.canvas.get_renderer())
+        transform = ax.transData.inverted()
+        bb = bb.transformed(transform)
+        xlim = (bb.x0 - 1.5 * space_around_text, samples)
+    else:
+        xlim = (0, samples)
+    ax.set(xlim=xlim)

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -670,8 +670,7 @@ def waveform(
         color: color of wave form and text
         background: color of background
         linewidth: line width of signal
-        figsize: size of figure.
-            If set to ``None`` it will use the default size
+        figsize: size of figure
         ylim: limits of y-axis
         ax: axes to plot on
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -680,32 +680,35 @@ def waveform(
 
             >>> import librosa
             >>> x, sr = librosa.load(librosa.ex('trumpet'))
-            >>> wavform(x, text='Trumpet')
+            >>> waveform(x, text='Trumpet')
 
     """
     x = np.atleast_2d(x)
     channels, samples = x.shape
     # TODO: include ax object
     ax = ax or plt.gca()
-    # TODO: check how to use sns.set() only for one plot
-    sns.set(
-        rc={
-            'axes.facecolor': background,
-            'figure.facecolor': background,
-            'axes.grid': False,
-            'figure.figsize': (8, 3 * channels),
-        },
-    )
+    ax.grid(False)
+    ax.set_facecolor(background)
+    plt.rcParams['figure.figsize'] = (8, 1 * channels)
+    sns.set(rc={'figure.figsize': (8, 1 * channels)})
+    # sns.set(
+    #     rc={
+    #         'axes.facecolor': background,
+    #         'figure.facecolor': background,
+    #         'axes.grid': False,
+    #         'figure.figsize': (8, 3 * channels),
+    #     },
+    # )
     for mono in x:
-        g = sns.lineplot(data=mono, color=color, linewidth=2.5)
+        sns.lineplot(data=mono, color=color, linewidth=2.5, ax=ax)
         # Remove all axis
         sns.despine(left=True, bottom=True)
-        g.tick_params(left=False, bottom=False)
-        _ = g.set(xticklabels=[], yticklabels=[])
+        ax.tick_params(left=False, bottom=False)
+        ax.set(xticklabels=[], yticklabels=[])
         # TODO: adjust position not based on samples, but on figure size
-        _ = plt.xlim([-0.15 * samples, samples])
-        _ = plt.ylim([-1, 1])
-        _ = plt.text(
+        plt.xlim([-0.15 * samples, samples])
+        plt.ylim([-1, 1])
+        plt.text(
             -0.02 * samples,
             0,
             text,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -656,7 +656,6 @@ def waveform(
         linewidth: float = 1.5,
         figsize: typing.Sequence[float] = (8, 1),
         ylim: typing.Sequence[float] = (-1, 1),
-        fig: plt.figure = None,
         ax: plt.Axes = None,
 ):
     r"""Plot waveform of a mono signal.

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -673,7 +673,7 @@ def waveform(
         linewidth: line width of signal
         ylim: limits of y-axis
         fig: Pre-existing figure for the plot.
-            Otherwise, call :func:`matplotlib.pyplot.gcf()` internally
+            Otherwise, calls :func:`matplotlib.pyplot.gcf()` internally
         ax: axes to plot on
 
     Raises:

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -672,8 +672,6 @@ def waveform(
         background: color of background
         linewidth: line width of signal
         ylim: limits of y-axis
-        fig: Pre-existing figure for the plot.
-            Otherwise, calls :func:`matplotlib.pyplot.gcf()` internally
         ax: axes to plot on
 
     Raises:
@@ -706,7 +704,7 @@ def waveform(
             >>> import librosa
             >>> import matplotlib.pyplot as plt
             >>> x, _ = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
-            >>> fig, axs = plt.subplots(2, figsize=(8, 3))
+            >>> _, axs = plt.subplots(2, figsize=(8, 3))
             >>> plt.subplots_adjust(hspace=0)
             >>> waveform(
             ...     x[0, :],
@@ -714,7 +712,6 @@ def waveform(
             ...     linewidth=0.5,
             ...     background='#389DCD',
             ...     color='#1B5975',
-            ...     fig=fig,
             ...     ax=axs[0],
             ... )
             >>> waveform(
@@ -723,7 +720,6 @@ def waveform(
             ...     linewidth=0.5,
             ...     background='#CA5144',
             ...     color='#742A23',
-            ...     fig=fig,
             ...     ax=axs[1],
             ... )
 
@@ -736,7 +732,6 @@ def waveform(
     default_figsize = plt.rcParams['figure.figsize']
     plt.rcParams['figure.figsize'] = (8, 1)
 
-    fig = fig or plt.gcf()
     ax = ax or plt.gca()
 
     x = np.atleast_2d(x)
@@ -774,6 +769,7 @@ def waveform(
             verticalalignment='center',
         )
         # Get left position of text and adjust xlim accordingly
+        fig = ax.get_figure()
         bb = text.get_window_extent(renderer=fig.canvas.get_renderer())
         transform = ax.transData.inverted()
         bb = bb.transformed(transform)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,6 +49,6 @@ spectrum
 .. autofunction:: spectrum
 
 waveform
--------
+--------
 
 .. autofunction:: waveform

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,3 +47,8 @@ spectrum
 --------
 
 .. autofunction:: spectrum
+
+waveform
+-------
+
+.. autofunction:: waveform

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ copybutton_prompt_is_regexp = True
 # Mapping to external documentation
 intersphinx_mapping = {
     'audmetric': ('https://audeering.github.io/audmetric/', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3/', None),
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 librosa
 sphinx
-sphinx-audeering-theme >=1.0.8
+sphinx-audeering-theme >=1.1.3
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinxcontrib-katex

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import audplot
@@ -37,3 +38,10 @@ import audplot
 def test_human_format(number, expected_string):
     string = audplot.human_format(number)
     assert string == expected_string
+
+
+def test_waveform():
+    # Fail for non mono signals
+    with pytest.raises(RuntimeError):
+        x = np.ones((2, 100))
+        audplot.waveform(x)


### PR DESCRIPTION
Adds `audplot.waveform` to plot a waveform of a monaural signal without any axis labels.
It provides the possibility to add some text in front of the waveform, and to change background and foreground color.

![image](https://user-images.githubusercontent.com/173624/139831406-56957935-14ad-441c-913d-d3e2e8e269c6.png)
