### PR TITLE
Fix scipy import for detection_error_tradeoff()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -10,8 +10,7 @@ import seaborn as sns
 # The scipy implementation is faster,
 # but scipy is not an official dependency of audplot
 try:
-    # from scipy.special import ndtri as inverse_normal_distribution
-    from audmath import inverse_normal_distribution
+    from scipy.special import ndtri as inverse_normal_distribution
 except ModuleNotFoundError:  # pragma: nocover
     from audmath import inverse_normal_distribution
 


### PR DESCRIPTION
The `scipy` support in `audplot` is only optional, but the import statement was commented out and it was never used for `audplot.detection_error_tradeoff()`. This is now corrected and the plot looks the same when using `scipy`:

![image](https://user-images.githubusercontent.com/173624/139218125-ef0c4deb-3af1-4357-b9a1-47b25e5f828d.png)
