### PR TITLE
Fix xticks positions for time axes

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -636,13 +636,9 @@ def spectrum(
     )
 
     # Add center frequencies as yticks labels
-    locs = ax.get_yticks()
-    yticks_spacing = int(locs[1] - locs[0])
-    # It might return negative yticks,
-    # that are not visible
-    negative_locs = locs[locs < 0]
-    labels = ['' for _ in negative_locs]
-    labels += [f'{cf:.1f}' for cf in centers[::yticks_spacing]]
-    ax.set_yticklabels(labels)
+    formatter = matplotlib.ticker.FuncFormatter(
+        lambda val, pos: round(centers[min(int(val), len(centers) - 1)], 1)
+    )
+    ax.yaxis.set_major_formatter(formatter)
 
     return image


### PR DESCRIPTION
Closes #10.

This fixes the xticks locations for time plots, by providing the scaled time axis to `matplotlib` so it can decide itself where to place the ticks. For the `imshow()` plots I had to add a little bit of code to still get the correct `y-axis` as we cannot handle the `x-axis` independently there as we have to use `extent` as argument.

Here are the new affected plots:

`audplot.cepstrum`

![image](https://user-images.githubusercontent.com/173624/139440514-59a1746d-aa3c-4cb5-9c42-56aee02d3bb3.png)

`audplot.signal`

![image](https://user-images.githubusercontent.com/173624/139440561-0c7f10e5-732f-4cdf-aa14-0dd2b0bb3226.png)

`audplot.spectrum`

![image](https://user-images.githubusercontent.com/173624/139440599-55dff3a3-1eea-42e8-805a-61916390c53f.png)

And the affected plot in `audsp` now looks like this

![image](https://user-images.githubusercontent.com/173624/139440996-4d3338fd-25a4-4ed7-96cd-5e402b6effcc.png)

