### PR TITLE
Also ensure real center frequency ticks

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -640,5 +640,10 @@ def spectrum(
         lambda val, pos: round(centers[min(int(val), len(centers) - 1)], 1)
     )
     ax.yaxis.set_major_formatter(formatter)
+    # Adjust yticks to be located at real center frequencies
+    locs = ax.get_yticks()
+    yticks_spacing = int(np.round(frequencies / len(locs)))
+    locs = list(range(0, frequencies - 1, yticks_spacing))
+    ax.set_yticks(locs)
 
     return image


### PR DESCRIPTION
Sorry, there was something I overlooked in #22.

It might happen that `imshow()` locates center frequencies at non-integer values. Similar to `audplot.cepstrum`, we don't want this to happen in `audplot.spectrum`.