### PR TITLE
Add label_aliases argument to confusion_matrix()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -125,8 +125,8 @@ def confusion_matrix(
         .. plot::
             :context: close-figs
 
-            >>> truth = ['A', 'B', 'B', 'B', 'C', 'C', 'C'] * 1000
-            >>> prediction = ['A', 'B', 'C', 'C', 'A', 'A', 'C'] * 1000
+            >>> truth = [0, 1, 1, 1, 2, 2, 2] * 1000
+            >>> prediction = [0, 1, 2, 2, 0, 0, 2] * 1000
             >>> confusion_matrix(truth, prediction)
 
         .. plot::
@@ -147,12 +147,12 @@ def confusion_matrix(
         .. plot::
             :context: close-figs
 
-            >>> confusion_matrix(truth, prediction, labels=['A', 'B', 'C', 'D'])
+            >>> confusion_matrix(truth, prediction, labels=[0, 1, 2, 3])
 
         .. plot::
             :context: close-figs
 
-            >>> confusion_matrix(truth, prediction, label_aliases={'A': 0, 'B': 1, 'C': 2})
+            >>> confusion_matrix(truth, prediction, label_aliases={0: 'A', 1: 'B', 2: 'C'})
 
     """  # noqa: 501
     ax = ax or plt.gca()

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -199,7 +199,10 @@ def confusion_matrix(
 
     # Get label names to present on x- and y-axis
     if label_aliases is not None:
-        labels = [label_aliases[label] for label in labels]
+        labels = [
+            label_aliases.get(label, label)
+            for label in labels
+        ]
 
     sns.heatmap(
         cm,

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -90,6 +90,7 @@ def confusion_matrix(
         prediction: typing.Union[typing.Sequence, pd.Series],
         *,
         labels: typing.Sequence = None,
+        label_aliases: typing.Dict = None,
         percentage: bool = False,
         show_both: bool = False,
         ax: plt.Axes = None,
@@ -102,6 +103,8 @@ def confusion_matrix(
         truth: truth values
         prediction: predicted values
         labels: labels to be included in confusion matrix
+        label_aliases: mapping to alias names for labels
+            to be presented in the plot
         percentage: if ``True`` present the confusion matrix
             with percentage values instead of absolute numbers
         show_both: if ``True`` and percentage is ``True``
@@ -146,6 +149,11 @@ def confusion_matrix(
 
             >>> confusion_matrix(truth, prediction, labels=['A', 'B', 'C', 'D'])
 
+        .. plot::
+            :context: close-figs
+
+            >>> confusion_matrix(truth, prediction, label_aliases={'A': 0, 'B': 1, 'C': 2})
+
     """  # noqa: 501
     ax = ax or plt.gca()
     if labels is None:
@@ -188,6 +196,10 @@ def confusion_matrix(
 
         combine_string = np.vectorize(combine_string)
         annot = pd.DataFrame(combine_string(annot, annot2), index=labels)
+
+    # Get label names to present on x- and y-axis
+    if label_aliases is not None:
+        labels = [label_aliases[label] for label in labels]
 
     sns.heatmap(
         cm,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,16 +22,11 @@ you can change the labels after plotting.
 
     truth = ['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C']
     prediction = ['A', 'A', 'B', 'B', 'C', 'C', 'A', 'A', 'C']
-    plot_labels = ['c1', 'c2', 'c3']
+    label_aliases = {'A': 'c1', 'B': 'c2', 'C': 'c3'}
 
     plt.figure(figsize=[2.8, 2.5])
     plt.title('Confusion Matrix')
-    audplot.confusion_matrix(truth, prediction)
-
-    # replace labels
-    locs, _ = plt.xticks()
-    plt.xticks(locs, plot_labels)
-    plt.yticks(locs, plot_labels)
+    audplot.confusion_matrix(truth, prediction, label_aliases=label_aliases)
 
     plt.tight_layout()
 


### PR DESCRIPTION
Closes #24 

This adds the `label_aliases` argument to `audplot.confusion_matrix()` to allow for displaying different names for the labels in the plot. The mapping has to be provided by a dict. This seems to me less error prone, then just a list with the labels in the right order.

![image](https://user-images.githubusercontent.com/173624/139593660-91d0d53b-f56c-417c-991d-78214906b36c.png)

and I also added an example

![image](https://user-images.githubusercontent.com/173624/139593642-df48bbb7-e099-4b5c-b8a4-200ce97a063a.png)
