### PR TITLE
Fix extent of time axis for cepstrum()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -62,7 +62,7 @@ def cepstrum(
     cc_matrix = cc_matrix[channel] if cc_matrix.ndim == 3 else cc_matrix
 
     n_cc, n_cepstra = cc_matrix.shape
-    extent = [0, (n_cepstra - 1) * hop_duration, -0.5, n_cc - 0.5]
+    extent = [0, n_cepstra * hop_duration, -0.5, n_cc - 0.5]
     ax.set_ylabel('Cepstral Coefficients')
     ax.set_xlabel('Time / s')
 


### PR DESCRIPTION
I wasn't sure before how to best estimate the time extent for `imshow()` plots and implemented accidentally two different solution for `cepstrum()` and `spectrum()`.

To get the correct solution, a short thought experiment. Let's assume we have a sampling rate of 3 Hz and a signal with three samples:

```
  o o o
 |     |
 0     1
```

As the extent starts before the first sample and ends after the last one, it should be 0s to 1s in this case.
Further this means we would have a hop duration of 0.33s between the samples as in `spectrum()` and `cepstrum()` we do not really have access to the sampling rate, but only to the hop duration in seconds.
This means the correct formula for the time extent would be:

```python
channels, samples = signal.shape
[0, samples * hop_duration]
```
