### PR TITLE
Use histplot in audplot.distribution()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -366,14 +366,15 @@ def distribution(
             :context: reset
             :include-source: false
 
-            import pandas as pd
+            import numpy as np
             from audplot import distribution
 
         .. plot::
             :context: close-figs
 
-            >>> truth = pd.Series([0, 1, 1, 2])
-            >>> prediction = pd.Series([0, 1, 2, 2])
+            >>> np.random.seed(0)
+            >>> truth = np.random.normal(loc=0.0, scale=1.0, size=1000)
+            >>> prediction = np.random.normal(loc=0.05, scale=0.5, size=1000)
             >>> distribution(truth, prediction)
 
     """
@@ -382,7 +383,7 @@ def distribution(
         data=np.array([truth, prediction]).T,
         columns=['Truth', 'Prediction'],
     )
-    sns.histplot(data, kde=True, ax=ax)
+    sns.histplot(data, kde=True, edgecolor='white', ax=ax)
     ax.grid(alpha=0.4)
     sns.despine(ax=ax)
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -378,8 +378,8 @@ def distribution(
 
     """
     ax = ax or plt.gca()
-    sns.distplot(truth, axlabel='', ax=ax)
-    sns.distplot(prediction, axlabel='', ax=ax)
+    sns.histplot(truth, kde=True, ax=ax)
+    sns.histplot(prediction, kde=True, ax=ax)
     ax.legend(['Truth', 'Prediction'])
     ax.grid(alpha=0.4)
     sns.despine(ax=ax)

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -378,9 +378,11 @@ def distribution(
 
     """
     ax = ax or plt.gca()
-    sns.histplot(truth, kde=True, ax=ax)
-    sns.histplot(prediction, kde=True, ax=ax)
-    ax.legend(['Truth', 'Prediction'])
+    data = pd.DataFrame(
+        data=np.array([truth, prediction]).T,
+        columns=['Truth', 'Prediction'],
+    )
+    sns.histplot(data, kde=True, ax=ax)
     ax.grid(alpha=0.4)
     sns.despine(ax=ax)
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -386,6 +386,8 @@ def distribution(
     sns.histplot(data, kde=True, edgecolor='white', ax=ax)
     ax.grid(alpha=0.4)
     sns.despine(ax=ax)
+    # Force y ticks at integer locations
+    ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(integer=True))
 
 
 def human_format(


### PR DESCRIPTION
Switch to `histplot()` for `audplot.distribution()`.

I also updated the example to be more in line with an regression example (this is where we use `audplot.distribution` in `audbenchmark`).

![image](https://user-images.githubusercontent.com/173624/139860936-14438c86-f823-4768-a1c5-58afe7601272.png)

But it also works for fewer samples, e.g. 10

![image](https://user-images.githubusercontent.com/173624/139860486-8f12f17e-5f44-4797-ba8c-19a9f9543ec7.png)