### PR TITLE
CI: use Python 3.8 for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
 
     - name: Setup Ubuntu
       run: |


### PR DESCRIPTION
Hopefully closes #32 

There seems to be known issues with newer versions of Python and `numba`, compare https://github.com/librosa/librosa/issues/1270

We did just specified the latest Python version in the publishing pipeline, which was not a good idea.
I changed it now to Python 3.8, which hopefully works during publishing.