### PR TITLE
Fix bars in distribution plot

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -387,7 +387,15 @@ def distribution(
         data=np.array([truth, prediction]).T,
         columns=['Truth', 'Prediction'],
     )
-    sns.histplot(data, kde=True, edgecolor='white', ax=ax)
+    sns.histplot(
+        data,
+        common_bins=False,
+        stat='density',
+        kde=True,
+        edgecolor=None,
+        kde_kws={'cut': 3},  # hard code like in distplot()
+        ax=ax,
+    )
     ax.grid(alpha=0.4)
     sns.despine(ax=ax)
     # Force y ticks at integer locations

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -390,7 +390,7 @@ def distribution(
     sns.histplot(
         data,
         common_bins=False,
-        stat='density',
+        stat='frequency',
         kde=True,
         edgecolor=None,
         kde_kws={'cut': 3},  # hard code like in distplot()


### PR DESCRIPTION
Closes #34 

![image](https://user-images.githubusercontent.com/10383417/141973056-d56c67af-d5db-4cbc-94e3-610a26f336e1.png)

~~This fixes the problem of inconsistent bars, but has the downside that we replace the frequency count with density. So maybe we should add an option to switch between the two solutions?~~