### PR TITLE
scatter(): proper linear regression model fit

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -496,6 +496,8 @@ def scatter(
         truth: typing.Union[typing.Sequence, pd.Series],
         prediction: typing.Union[typing.Sequence, pd.Series],
         *,
+        fit: bool = False,
+        order:int = 1,
         ax: matplotlib.axes.Axes = None,
 ):
     r"""Scatter plot of truth and predicted values.
@@ -503,6 +505,10 @@ def scatter(
     Args:
         truth: truth values
         prediction: predicted values
+        fit: if ``True``,
+            fit a regression model relating the x and y variables
+        order: if greater than 1,
+            estimate a polynomial regression model (see ``fit``)
         ax: pre-existing axes for the plot.
             Otherwise, calls :func:`matplotlib.pyplot.gca()` internally
 
@@ -518,15 +524,17 @@ def scatter(
 
             >>> truth = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             >>> prediction = [0.1, 0.8, 2.3, 2.4, 3.9, 5, 6.2, 7.1, 7.8, 9, 9]
-            >>> scatter(truth, prediction)
+            >>> scatter(truth, prediction, fit=True)
 
     """
     ax = ax or plt.gca()
     sns.regplot(
         x=truth,
         y=prediction,
+        fit_reg=fit,
+        line_kws={'color': 'r'},
+        order=order,
         ax=ax,
-        line_kws={'color': 'r'}
     )
     ax.set_xlabel('Truth')
     ax.set_ylabel('Prediction')

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -522,20 +522,15 @@ def scatter(
 
     """
     ax = ax or plt.gca()
-    minimum = min([min(truth), min(prediction)])
-    maximum = max([max(truth), max(prediction)])
-    ax.scatter(truth, prediction)
-    ax.plot(
-        [minimum, maximum],
-        [minimum, maximum],
-        color='r',
+    sns.regplot(
+        x=truth,
+        y=prediction,
+        ax=ax,
+        line_kws={'color': 'r'}
     )
-    ax.set_xlim(minimum, maximum)
-    ax.set_ylim(minimum, maximum)
     ax.set_xlabel('Truth')
     ax.set_ylabel('Prediction')
     ax.grid(alpha=0.4)
-    ax.set_axisbelow(True)
     sns.despine(ax=ax)
 
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -497,7 +497,7 @@ def scatter(
         prediction: typing.Union[typing.Sequence, pd.Series],
         *,
         fit: bool = False,
-        order:int = 1,
+        order: int = 1,
         ax: matplotlib.axes.Axes = None,
 ):
     r"""Scatter plot of truth and predicted values.


### PR DESCRIPTION
Switch to [sns.regplot()](https://seaborn.pydata.org/generated/seaborn.regplot.html#seaborn.regplot) in `audplot.scatter()`, which optionally applies a linear or polynomial regression model fit.

![image](https://user-images.githubusercontent.com/10383417/145548033-07feaa8d-409b-4e39-bb69-5af9795e79d2.png)

### Example

```python
N = 1000
truth = np.random.uniform(size=N)
prediction = (truth ** 3) + np.random.random(size=N)

_, axs = plt.subplots(3, 1)
audplot.scatter(truth, prediction, ax=axs[0])
audplot.scatter(truth, prediction, fit=True, ax=axs[1])
audplot.scatter(truth, prediction, fit=True, order=3, ax=axs[2])

plt.tight_layout()
plt.show()
```

![image](https://user-images.githubusercontent.com/10383417/145548381-b3bcdff2-f3d1-44e1-8d94-d2b92dfebfa5.png)

