### PR TITLE
Force fit argument of scatter to use a fixed seed

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -535,6 +535,7 @@ def scatter(
         line_kws={'color': 'r'},
         order=order,
         ax=ax,
+        seed=0,
     )
     ax.set_xlabel('Truth')
     ax.set_ylabel('Prediction')


### PR DESCRIPTION
At the moment I face the problem that `audplot.scatter(..., fit=True)` creates every time a slightly different output (when stored as PNG) as the fitting involves some randomness in the form of bootstrapping. To avoid this I would propose that we call `seaborn.regplot()` with a fixed seed.