### PR TITLE
Require flake<5.0.0 + matplotlib!=3.6.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,6 @@ signal processing (e.g. spectral images)
 and machine learning problems (e.g. confusion matrix).
 
 
-
 .. badges images and links:
 .. |tests| image:: https://github.com/audeering/audplot/workflows/Test/badge.svg
     :target: https://github.com/audeering/audplot/actions?query=workflow%3ATest

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ signal processing (e.g. spectral images)
 and machine learning problems (e.g. confusion matrix).
 
 
+
 .. badges images and links:
 .. |tests| image:: https://github.com/audeering/audplot/workflows/Test/badge.svg
     :target: https://github.com/audeering/audplot/actions?query=workflow%3ATest

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ packages = find:
 install_requires =
     audmath
     audmetric >=1.1.0
+    # https://github.com/matplotlib/matplotlib/issues/24127
+    matplotlib != 3.6.1
     seaborn
 setup_requires =
     setuptools_scm

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 librosa
 pytest
 pytest-flake8


### PR DESCRIPTION
Closes #41 

`matplotlib` 3.6.1 has a bug that lets it fail for `audplot.distribution()`, see https://github.com/matplotlib/matplotlib/issues/24127.

Hence, I propose to blacklist it here.

I also had to restrict `flake` to make the tests work.