### PR TITLE
Speedup audplot.waveform()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -798,6 +798,20 @@ def waveform(
     channels, samples = x.shape
     if channels > 1:
         raise RuntimeError('Only mono signals are supported.')
+
+    # Split array in smaller parts
+    # for downsampling
+    x_split = np.array_split(x[0], 1000)
+    x_max = [x.max() for x in x_split]
+    x_min = [x.min() for x in x_split]
+
+    # ...
+    # Plot both x_max and x_min lines
+    # and fill area between them
+
+    # ...
+    # Add rms_max and rms_min in addition
+
     # Set colors
     ax.grid(False)
     ax.set_facecolor(background)

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -801,9 +801,8 @@ def waveform(
         raise RuntimeError('Only mono signals are supported.')
 
     # Downsample signal to match pixels of figure
+    # by using min and max of sub-arrays
     pixels = int(fig.get_figwidth() * fig.get_dpi())
-    # Split array in smaller parts
-    # for downsampling
     x_split = np.array_split(x[0], int(pixels))
     x_max = [x.max() for x in x_split]
     x_min = [x.min() for x in x_split]

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -803,7 +803,7 @@ def waveform(
     # Downsample signal to match pixels of figure
     # by using min and max of sub-arrays
     pixels = int(fig.get_figwidth() * fig.get_dpi())
-    x_split = np.array_split(x[0], int(pixels))
+    x_split = np.array_split(x[0], pixels)
     x_max = [x.max() for x in x_split]
     x_min = [x.min() for x in x_split]
 

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -808,52 +808,15 @@ def waveform(
     x_max = [x.max() for x in x_split]
     x_min = [x.min() for x in x_split]
 
-    def rms(x):
-        return np.sqrt(np.mean(np.square(x)))
-
-    x_rms_max = [rms(x) for x in x_split]
-    x_rms_min = [-x for x in x_rms_max]
-
-    # ...
-    # Plot both x_max and x_min lines
-    # and fill area between them
-
-    # ...
-    # Add rms_max and rms_min in addition
-
     # Set colors
     ax.grid(False)
     ax.set_facecolor(background)
     # Plot waveform
-    # sns.lineplot(
-    #     data=x,
-    #     color=color,
-    #     linewidth=linewidth,
-    #     ax=ax,
-    # )
     ax.fill_between(
         x=range(pixels),
         y1=x_min,
         y2=x_max,
         color=color,
-        linewidth=linewidth,
-    )
-
-    def adjust_lightness(color, amount=0.5):
-        import matplotlib.colors as mc
-        import colorsys
-        try:
-            c = mc.cnames[color]
-        except:
-            c = color
-        c = colorsys.rgb_to_hls(*mc.to_rgb(c))
-        return colorsys.hls_to_rgb(c[0], max(0, min(1, amount * c[1])), c[2])
-
-    ax.fill_between(
-        x=range(pixels),
-        y1=x_rms_min,
-        y2=x_rms_max,
-        color=adjust_lightness(color, amount=1.2),
         linewidth=linewidth,
     )
     ax.set(ylim=ylim)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,11 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
 import audplot
+
+
+np.random.seed(1)
 
 
 @pytest.mark.parametrize(
@@ -45,3 +49,7 @@ def test_waveform():
     with pytest.raises(RuntimeError):
         x = np.ones((2, 100))
         audplot.waveform(x)
+    signal = np.random.randn(2000)
+    for n in [400, 800, 1200]:
+        audplot.waveform(signal[:n])
+        plt.close()


### PR DESCRIPTION
This downsamples a waveform before plotting it to the number of available pixels.
Downsampling is achieved by splitting the signal into a number of sub-arrays corresponding to the number of pixels. For each sub-array we calculate min and max and fill the area between all min and max values during plotting [as done by audacity](https://stackoverflow.com/a/41814425).

This speeds up plotting dramatically with changing the resulting figure only marginally.
I was wondering before why building some of our documentations took very long,
and `audmath.waveform()` was the main reason.

E.g. the execution of
```python
audplot.waveform(np.random.randn(44100))
plt.savefig('test.png')
```
is now reduced from **14.87 s** to **0.07 s**.

![image](https://user-images.githubusercontent.com/173624/205254122-eb969b52-11ba-49e2-ac1f-d1e56e3eca62.png)
