### PR TITLE
DOC: mention x-axis scaling for waveform()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -722,6 +722,13 @@ def waveform(
 
     Shows only the outline of a time signal
     without showing any axis or values.
+    Long signals will be downsampled
+    for faster plotting.
+    As a consequence,
+    the x-axis no longer reflects
+    the length of the signal in samples.
+    The actual length can be inspected
+    with ``ax.get_xlim()``.
 
     Args:
         x: array with signal values


### PR DESCRIPTION
I tested the new `audplot.waveform()` code and it works as expected, but I also had to change code where I was setting the `xlim` after plotting as the x-axis now no longer reflects the actual signal length.
This pull request updates the docstring of `audplot.waveform()` mentioning that the x-axis might be scaled.

![image](https://user-images.githubusercontent.com/173624/205586665-b957a479-2eb2-4f53-8413-e443164bca6b.png)
