### PR TITLE
CI: use Python 3.10 when publishing package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Setup Ubuntu
       run: |


### PR DESCRIPTION
Uses Python 3.10 as default in all actions. This was already the case in all of them, besides `publish.yml`.