### PR TITLE
Suppress pandas FutureWarning for applymap()

### DIFF
--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -179,7 +179,7 @@ def confusion_matrix(
         # Catch warning,
         # to still support older pandas versions.
         # See https://github.com/audeering/audplot/pull/69
-        warnings.simplefilter(action='ignore', category=FutureWarning)
+        warnings.simplefilter(action="ignore", category=FutureWarning)
         if percentage:
             annot = cm.applymap(lambda x: f"{100 * x:.0f}%")
         else:
@@ -199,7 +199,7 @@ def confusion_matrix(
             # Catch warning,
             # to still support older pandas versions.
             # See https://github.com/audeering/audplot/pull/69
-            warnings.simplefilter(action='ignore', category=FutureWarning)
+            warnings.simplefilter(action="ignore", category=FutureWarning)
             if percentage:
                 annot2 = cm2.applymap(lambda x: human_format(x))
             else:

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -1,5 +1,6 @@
 import math
 import typing
+import warnings
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -174,10 +175,15 @@ def confusion_matrix(
     cm = pd.DataFrame(cm, index=labels)
 
     # Set format of first row labels in confusion matrix
-    if percentage:
-        annot = cm.applymap(lambda x: f"{100 * x:.0f}%")
-    else:
-        annot = cm.applymap(lambda x: human_format(x))
+    with warnings.catch_warnings():
+        # Catch warning,
+        # to still support older pandas versions.
+        # See https://github.com/audeering/audplot/pull/69
+        warnings.simplefilter(action='ignore', category=FutureWarning)
+        if percentage:
+            annot = cm.applymap(lambda x: f"{100 * x:.0f}%")
+        else:
+            annot = cm.applymap(lambda x: human_format(x))
 
     # Add a second row of annotations if requested
     if show_both:
@@ -188,10 +194,16 @@ def confusion_matrix(
             normalize=not percentage,
         )
         cm2 = pd.DataFrame(cm2, index=labels)
-        if percentage:
-            annot2 = cm2.applymap(lambda x: human_format(x))
-        else:
-            annot2 = cm2.applymap(lambda x: f"{100 * x:.0f}%")
+
+        with warnings.catch_warnings():
+            # Catch warning,
+            # to still support older pandas versions.
+            # See https://github.com/audeering/audplot/pull/69
+            warnings.simplefilter(action='ignore', category=FutureWarning)
+            if percentage:
+                annot2 = cm2.applymap(lambda x: human_format(x))
+            else:
+                annot2 = cm2.applymap(lambda x: f"{100 * x:.0f}%")
 
         # Combine strings from two dataframes
         # by vectorizing the underlying function.


### PR DESCRIPTION
Closes #64 

As we have seen in https://github.com/audeering/audplot/pull/69, that we cannot avoid the future warning of `pandas` and stay with support for Python 3.8, we suppress the warning for now.

I created https://github.com/audeering/audplot/issues/71 to track renaming later.