### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from collections.abc import Sequence
 import math

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
+from collections.abc import Sequence
 import math
-import typing
 import warnings
 
 import matplotlib
@@ -92,11 +93,11 @@ def cepstrum(
 
 
 def confusion_matrix(
-    truth: typing.Union[typing.Sequence, pd.Series],
-    prediction: typing.Union[typing.Sequence, pd.Series],
+    truth: Sequence | pd.Series,
+    prediction: Sequence | pd.Series,
     *,
-    labels: typing.Sequence = None,
-    label_aliases: typing.Dict = None,
+    labels: Sequence = None,
+    label_aliases: dict = None,
     percentage: bool = False,
     show_both: bool = False,
     ax: matplotlib.axes.Axes = None,
@@ -235,15 +236,15 @@ def confusion_matrix(
 
 
 def detection_error_tradeoff(
-    x: typing.Union[typing.Sequence, pd.Series],
-    y: typing.Union[typing.Sequence, pd.Series],
+    x: Sequence | pd.Series,
+    y: Sequence | pd.Series,
     *,
     error_rates: bool = False,
-    xlim: typing.Sequence = [0.001, 0.5],
-    ylim: typing.Sequence = [0.001, 0.5],
+    xlim: Sequence = [0.001, 0.5],
+    ylim: Sequence = [0.001, 0.5],
     label: str = None,
     ax: matplotlib.axes.Axes = None,
-) -> typing.Callable:
+) -> Callable:
     r"""Detection error tradeoff curve.
 
     A `detection error tradeoff (DET)`_ curve
@@ -360,8 +361,8 @@ def detection_error_tradeoff(
 
 
 def distribution(
-    truth: typing.Union[typing.Sequence, pd.Series],
-    prediction: typing.Union[typing.Sequence, pd.Series],
+    truth: Sequence | pd.Series,
+    prediction: Sequence | pd.Series,
     *,
     ax: matplotlib.axes.Axes = None,
 ):
@@ -411,7 +412,7 @@ def distribution(
 
 
 def human_format(
-    number: typing.Union[int, float],
+    number: int | float,
 ) -> str:
     r"""Display large or small numbers in a human readable way.
 
@@ -501,8 +502,8 @@ def human_format(
 
 
 def scatter(
-    truth: typing.Union[typing.Sequence, pd.Series],
-    prediction: typing.Union[typing.Sequence, pd.Series],
+    truth: Sequence | pd.Series,
+    prediction: Sequence | pd.Series,
     *,
     fit: bool = False,
     order: int = 1,
@@ -552,8 +553,8 @@ def scatter(
 
 
 def series(
-    truth: typing.Union[typing.Sequence, pd.Series],
-    prediction: typing.Union[typing.Sequence, pd.Series],
+    truth: Sequence | pd.Series,
+    prediction: Sequence | pd.Series,
     *,
     ax: matplotlib.axes.Axes = None,
 ):
@@ -720,10 +721,10 @@ def waveform(
     x: np.ndarray,
     *,
     text: str = None,
-    color: typing.Union[str, typing.Sequence[float]] = "#E13B41",
-    background: typing.Union[str, typing.Sequence[float]] = "#FFFFFF00",
+    color: str | Sequence[float] = "#E13B41",
+    background: str, | Sequence[float] = "#FFFFFF00",
     linewidth: float = 1.5,
-    ylim: typing.Sequence[float] = (-1, 1),
+    ylim: Sequence[float] = (-1, 1),
     ax: matplotlib.axes.Axes = None,
 ):
     r"""Plot waveform of a mono signal.

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -242,8 +242,8 @@ def detection_error_tradeoff(
     y: Sequence | pd.Series,
     *,
     error_rates: bool = False,
-    xlim: Sequence = [0.001, 0.5],
-    ylim: Sequence = [0.001, 0.5],
+    xlim: Sequence = (0.001, 0.5),
+    ylim: Sequence = (0.001, 0.5),
     label: str = None,
     ax: matplotlib.axes.Axes = None,
 ) -> Callable:

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -722,7 +722,7 @@ def waveform(
     *,
     text: str = None,
     color: str | Sequence[float] = "#E13B41",
-    background: str, | Sequence[float] = "#FFFFFF00",
+    background: str | Sequence[float] = "#FFFFFF00",
     linewidth: float = 1.5,
     ylim: Sequence[float] = (-1, 1),
     ax: matplotlib.axes.Axes = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Removes support for Python 3.8, which has reached its end-of-life.

As with Python 3.9 we can also use `list[str]` for type hinting instead of `typing.List[str]`, I also removed the `typing` module and replaced it with other code, including the [type hinting union syntax](https://docs.python.org/3.10/whatsnew/3.10.html#pep-604-new-type-union-operator) introduced in Python 3.10, which is now also shown in the compiled documentation and makes it easier to read:

![image](https://github.com/user-attachments/assets/367c20a2-b24c-453b-9d96-18e8f256dadd)


## Summary by Sourcery

Remove support for Python 3.8 by updating type hint syntax to use PEP 604 style and adjusting CI configuration to exclude Python 3.8.

CI:
- Update CI configuration to exclude Python 3.8 from the testing matrix.

Chores:
- Remove support for Python 3.8 from the codebase.