### PR TITLE
TST: update ruff and codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:


### PR DESCRIPTION
This updates `ruff` and `codespell` in the pre-commit config to its latest versions (which I think we should do once a year).

All tests are running fine with the newer versions, even though `ruff` have introduced some [breaking changes](https://github.com/astral-sh/ruff/blob/main/BREAKING_CHANGES.md).

## Summary by Sourcery

Update the pre-commit configuration to use the latest versions of ruff and codespell.

Build:
- Update ruff to version v0.7.0 in the pre-commit configuration.
- Update codespell to version v2.3.0 in the pre-commit configuration.