### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from collections.abc import Sequence
 import math

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
+requires-python = '>=3.10'
 dependencies = [
     'audmath',
     'audmetric >=1.1.0',


### PR DESCRIPTION
Remove support for Python 3.9

## Summary by Sourcery

Remove Python 3.9 support by dropping it from the CI matrix and package metadata and raising the minimum Python requirement to 3.10.

Build:
- Drop Python 3.9 from CI test matrix

Chores:
- Update Python requirement to >=3.10 in pyproject.toml
- Remove Python 3.9 classifier from package metadata