### PR TITLE
TST: use Python 3.12 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install uv
       uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Setup Ubuntu
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.10
+  python: python3.12
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Use Python 3.12 as default in tests.

## Summary by Sourcery

Use Python 3.12 as the default interpreter across tests, CI workflows, and pre-commit configuration.

CI:
- Upgrade actions/setup-python to 3.12 in linter, documentation, and publish GitHub workflows.

Chores:
- Bump default_language_version python to python3.12 in .pre-commit-config.yaml.