### PR TITLE
Include only audplot* in Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
+include = ['audplot*']
 
 # ----- setuptools_scm ----------------------------------------------------
 #


### PR DESCRIPTION
This restricts the files included in the Python package to `audplot*`.

Same fix as audeering/audb#560 (audeering/audb#559): the empty `[tool.setuptools.packages.find]` defaults to `namespaces = true`, causing setuptools to also pick up `tests/`, `docs/`, `benchmarks/`, and `build/` as top-level namespace packages. They end up installed under `site-packages/` and shadow any local `tests/` or `docs/` packages in downstream projects.