### PR TITLE
Depend on pandas>=2.1 and fix pandas>=3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Test with pytest
       run: |
         uv run pytest
+      env:
+        # Use a non-interactive backend to avoid flaky Tcl/Tk
+        # errors on Windows runners, see
+        # https://github.com/actions/runner-images/issues/7776
+        MPLBACKEND: Agg
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/audplot/core/api.py
+++ b/audplot/core/api.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 from collections.abc import Sequence
 import math
-import warnings
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -178,15 +177,10 @@ def confusion_matrix(
     cm = pd.DataFrame(cm, index=labels)
 
     # Set format of first row labels in confusion matrix
-    with warnings.catch_warnings():
-        # Catch warning,
-        # to still support older pandas versions.
-        # See https://github.com/audeering/audplot/pull/69
-        warnings.simplefilter(action="ignore", category=FutureWarning)
-        if percentage:
-            annot = cm.applymap(lambda x: f"{100 * x:.0f}%")
-        else:
-            annot = cm.applymap(lambda x: human_format(x))
+    if percentage:
+        annot = cm.map(lambda x: f"{100 * x:.0f}%")
+    else:
+        annot = cm.map(lambda x: human_format(x))
 
     # Add a second row of annotations if requested
     if show_both:
@@ -198,15 +192,10 @@ def confusion_matrix(
         )
         cm2 = pd.DataFrame(cm2, index=labels)
 
-        with warnings.catch_warnings():
-            # Catch warning,
-            # to still support older pandas versions.
-            # See https://github.com/audeering/audplot/pull/69
-            warnings.simplefilter(action="ignore", category=FutureWarning)
-            if percentage:
-                annot2 = cm2.applymap(lambda x: human_format(x))
-            else:
-                annot2 = cm2.applymap(lambda x: f"{100 * x:.0f}%")
+        if percentage:
+            annot2 = cm2.map(lambda x: human_format(x))
+        else:
+            annot2 = cm2.map(lambda x: f"{100 * x:.0f}%")
 
         # Combine strings from two dataframes
         # by vectorizing the underlying function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     'audmetric >=1.1.0',
     # https://github.com/matplotlib/matplotlib/issues/24127
     'matplotlib != 3.6.1',
+    'pandas >=2.1.0',
     'seaborn',
 ]
 # Get version dynamically from git


### PR DESCRIPTION
Closes #71 
Closes #80 

Updates code in `confusion_matrix()` to work with `pandas>=3.0`. As this requires at least `pandas>=2.1`, we add those to the dependencies.

It also requires to use a non-interactive matplotlib backend to avoid Tcl errors in Windows runners.